### PR TITLE
Update for modern GHC

### DIFF
--- a/UI/Command.hs
+++ b/UI/Command.hs
@@ -3,9 +3,9 @@ module UI.Command (
         appArgs,
         appConfig,
         Application (..),
-	Command (..),
+        Command (..),
         defCmd,
-	appMain,
+        appMain,
         appMainWithOptions
 ) where
 

--- a/UI/Command/App.hs
+++ b/UI/Command/App.hs
@@ -1,9 +1,9 @@
 module UI.Command.App (
         App,
-	appArgs,
-	appConfig,
+        appArgs,
+        appConfig,
 
-	AppContext(..)
+        AppContext(..)
 ) where
 
 import Data.Default

--- a/UI/Command/Command.hs
+++ b/UI/Command/Command.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE FlexibleInstances, TypeSynonymInstances #-}
 module UI.Command.Command (
-	Command (..),
+        Command (..),
         defCmd
 ) where
 

--- a/UI/Command/Doc.hs
+++ b/UI/Command/Doc.hs
@@ -1,12 +1,12 @@
 module UI.Command.Doc (
-	helpCmd, manCmd,
+        helpCmd, manCmd,
         helpErr, help, man
 )where
 
 import Data.Default
 import Data.Char (toUpper)
 
-import System.Locale (defaultTimeLocale)
+import Data.Time.Locale.Compat (defaultTimeLocale)
 import Data.Time.Format (formatTime)
 import Data.Time.Clock (getCurrentTime)
 import System.IO (hPutStr, stderr)
@@ -39,13 +39,13 @@ helpCmd = def {
 
 helpErr app = do
         args <- appArgs
-	liftIO $ mapM_ (hPutStr stderr) $ longHelp app args
+        liftIO $ mapM_ (hPutStr stderr) $ longHelp app args
 
 --help :: (Default opts, Default config) => Application opts config -> [String] -> IO ()
 -- help :: (Default opts, Default config) => Application opts config -> App config ()
 help app = do
         args <- appArgs
-	liftIO $ mapM_ putStr $ longHelp app args
+        liftIO $ mapM_ putStr $ longHelp app args
 
 longHelp :: (Default opts, Default config) => Application opts config -> [String] -> [String]
 -- | "app help" with no arguments: Give a list of all cmdcommands
@@ -105,10 +105,10 @@ manCmd = def {
 
 -- man :: (Default opts, Default config) => Application opts config -> [String] -> IO ()
 man app = do
-        args <- appArgs
-        currentTime <- liftIO $ getCurrentTime
-	let dateStamp = formatTime defaultTimeLocale "%B %Y" currentTime
-	liftIO $ putStrLn . concat $ longMan app dateStamp args
+       args <- appArgs
+       currentTime <- liftIO $ getCurrentTime
+       let dateStamp = formatTime defaultTimeLocale "%B %Y" currentTime
+       liftIO $ putStrLn . concat $ longMan app dateStamp args
 
 manSH :: String -> String
 manSH s = "\n.SH " ++ s ++ "\n\n"
@@ -116,9 +116,9 @@ manSH s = "\n.SH " ++ s ++ "\n\n"
 headerMan :: (Default opts, Default config) => Application opts config -> String -> [String]
 headerMan app dateStamp = [unwords [".TH", u, "1", quote dateStamp, quote (appName app), project, "\n"]]
     where
-        u = map toUpper (appName app)
-	project | appProject app == def = ""
-	        | otherwise = quote $ appProject app
+       u = map toUpper (appName app)
+       project | appProject app == def = ""
+               | otherwise = quote $ appProject app
 
 synopsisMan :: (Default opts, Default config) => Application opts config -> String -> [Command config] -> [String]
 synopsisMan app _ [] =
@@ -147,12 +147,12 @@ descMan desc = [manSH "DESCRIPTION", desc, "\n"]
 longMan :: (Default opts, Default config) => Application opts config -> String -> [String] -> [String]
 longMan app dateStamp [] =
         headerMan app dateStamp ++
-	[manSH "NAME"] ++
+       [manSH "NAME"] ++
         [appName app, " \\- ", appShortDesc app, "\n\n"] ++
         synopsisMan app "COMMAND" [] ++
         descMan (".B " ++ appName app ++ "\n" ++ appLongDesc app) ++
         map (categoryMan app) (appCategories app) ++
-	authorsMan app "" ++
+       authorsMan app "" ++
         seeAlsoMan app
 
 longMan app dateStamp (command:_) = contextMan app dateStamp command m
@@ -180,7 +180,7 @@ contextMan app dateStamp command i@(item:_) =
         descMan (cmdSynopsis item) ++
         description ++
         examples ++
-	authorsMan app command
+       authorsMan app command
     where
         description | cmdShortDesc item == "" = []
                     | otherwise = ["\n" ++ cmdShortDesc item]

--- a/UI/Command/Doc.hs
+++ b/UI/Command/Doc.hs
@@ -105,10 +105,10 @@ manCmd = def {
 
 -- man :: (Default opts, Default config) => Application opts config -> [String] -> IO ()
 man app = do
-       args <- appArgs
-       currentTime <- liftIO $ getCurrentTime
-       let dateStamp = formatTime defaultTimeLocale "%B %Y" currentTime
-       liftIO $ putStrLn . concat $ longMan app dateStamp args
+        args <- appArgs
+        currentTime <- liftIO $ getCurrentTime
+        let dateStamp = formatTime defaultTimeLocale "%B %Y" currentTime
+        liftIO $ putStrLn . concat $ longMan app dateStamp args
 
 manSH :: String -> String
 manSH s = "\n.SH " ++ s ++ "\n\n"
@@ -116,9 +116,9 @@ manSH s = "\n.SH " ++ s ++ "\n\n"
 headerMan :: (Default opts, Default config) => Application opts config -> String -> [String]
 headerMan app dateStamp = [unwords [".TH", u, "1", quote dateStamp, quote (appName app), project, "\n"]]
     where
-       u = map toUpper (appName app)
-       project | appProject app == def = ""
-               | otherwise = quote $ appProject app
+        u = map toUpper (appName app)
+        project | appProject app == def = ""
+                | otherwise = quote $ appProject app
 
 synopsisMan :: (Default opts, Default config) => Application opts config -> String -> [Command config] -> [String]
 synopsisMan app _ [] =
@@ -147,12 +147,12 @@ descMan desc = [manSH "DESCRIPTION", desc, "\n"]
 longMan :: (Default opts, Default config) => Application opts config -> String -> [String] -> [String]
 longMan app dateStamp [] =
         headerMan app dateStamp ++
-       [manSH "NAME"] ++
+        [manSH "NAME"] ++
         [appName app, " \\- ", appShortDesc app, "\n\n"] ++
         synopsisMan app "COMMAND" [] ++
         descMan (".B " ++ appName app ++ "\n" ++ appLongDesc app) ++
         map (categoryMan app) (appCategories app) ++
-       authorsMan app "" ++
+        authorsMan app "" ++
         seeAlsoMan app
 
 longMan app dateStamp (command:_) = contextMan app dateStamp command m
@@ -180,7 +180,7 @@ contextMan app dateStamp command i@(item:_) =
         descMan (cmdSynopsis item) ++
         description ++
         examples ++
-       authorsMan app command
+        authorsMan app command
     where
         description | cmdShortDesc item == "" = []
                     | otherwise = ["\n" ++ cmdShortDesc item]

--- a/UI/Command/Main.hs
+++ b/UI/Command/Main.hs
@@ -1,5 +1,5 @@
 module UI.Command.Main (
-	appMain,
+        appMain,
         appMainWithOptions
 ) where
 
@@ -26,8 +26,8 @@ initApp :: (Default opts, Default config)
         => Application opts config -> [String]
         -> IO (AppContext config)
 initApp app args = do
-        (config, args) <- processArgs app args
-	return $ AppContext config args
+       (config, args) <- processArgs app args
+       return $ AppContext config args
 
 processArgs :: (Default opts, Default config)
             => Application opts config -> [String]
@@ -49,17 +49,17 @@ processArgs app args = do
 --
 appMain :: Application () () -> IO ()
 appMain app = do
-        allArgs <- getArgs
-	when (any isHelp allArgs) $ showHelp app allArgs
-	when (any isVersion allArgs) $ showVersion app
-	handleCommand app allArgs
+       allArgs <- getArgs
+       when (any isHelp allArgs) $ showHelp app allArgs
+       when (any isVersion allArgs) $ showVersion app
+       handleCommand app allArgs
 
 appMainWithOptions :: (Default opts, Default config) => Application opts config -> IO ()
 appMainWithOptions app = do
-        allArgs <- getArgs
-	when (any isHelp allArgs) $ showHelp app allArgs
-	when (any isVersion allArgs) $ showVersion app
-	handleCommand app allArgs
+       allArgs <- getArgs
+       when (any isHelp allArgs) $ showHelp app allArgs
+       when (any isVersion allArgs) $ showVersion app
+       handleCommand app allArgs
 
 helpStrings :: [[Char]]
 helpStrings = ["--help", "-h", "-?"]
@@ -75,8 +75,8 @@ isVersion x = elem x versionStrings
 
 showHelp :: (Default opts, Default config) => Application opts config -> [String] -> IO ()
 showHelp app args = do
-        (initApp app args) >>= runReaderT (help app)
-	exitWith ExitSuccess
+       (initApp app args) >>= runReaderT (help app)
+       exitWith ExitSuccess
 
 showVersion :: (Default opts, Default config) => Application opts config -> IO ()
 showVersion app = do
@@ -92,11 +92,11 @@ handleCommand app (command:args)
         | command == "man" = showMan
         | otherwise = initApp app args >>= loop1
         where
-                showMan = initApp app args >>= loopMan
-	        loopMan st = runReaderT (man app) st
-	        loop1 st = runReaderT run st
-                -- docCmds :: (Default config1) => [Command config1]
-                -- docCmds = [helpCmd{cmdHandler = help app}, manCmd{cmdHandler = man app}]
-                run = act $ filter (\x -> cmdName x == command) (appCmds app)
-	        act [] = helpErr app
-		act (s:_) = cmdHandler s
+               showMan = initApp app args >>= loopMan
+               loopMan st = runReaderT (man app) st
+               loop1 st = runReaderT run st
+               -- docCmds :: (Default config1) => [Command config1]
+               -- docCmds = [helpCmd{cmdHandler = help app}, manCmd{cmdHandler = man app}]
+               run = act $ filter (\x -> cmdName x == command) (appCmds app)
+               act [] = helpErr app
+               act (s:_) = cmdHandler s

--- a/UI/Command/Main.hs
+++ b/UI/Command/Main.hs
@@ -26,8 +26,8 @@ initApp :: (Default opts, Default config)
         => Application opts config -> [String]
         -> IO (AppContext config)
 initApp app args = do
-       (config, args) <- processArgs app args
-       return $ AppContext config args
+        (config, args) <- processArgs app args
+        return $ AppContext config args
 
 processArgs :: (Default opts, Default config)
             => Application opts config -> [String]
@@ -49,17 +49,17 @@ processArgs app args = do
 --
 appMain :: Application () () -> IO ()
 appMain app = do
-       allArgs <- getArgs
-       when (any isHelp allArgs) $ showHelp app allArgs
-       when (any isVersion allArgs) $ showVersion app
-       handleCommand app allArgs
+        allArgs <- getArgs
+        when (any isHelp allArgs) $ showHelp app allArgs
+        when (any isVersion allArgs) $ showVersion app
+        handleCommand app allArgs
 
 appMainWithOptions :: (Default opts, Default config) => Application opts config -> IO ()
 appMainWithOptions app = do
-       allArgs <- getArgs
-       when (any isHelp allArgs) $ showHelp app allArgs
-       when (any isVersion allArgs) $ showVersion app
-       handleCommand app allArgs
+        allArgs <- getArgs
+        when (any isHelp allArgs) $ showHelp app allArgs
+        when (any isVersion allArgs) $ showVersion app
+        handleCommand app allArgs
 
 helpStrings :: [[Char]]
 helpStrings = ["--help", "-h", "-?"]
@@ -75,8 +75,8 @@ isVersion x = elem x versionStrings
 
 showHelp :: (Default opts, Default config) => Application opts config -> [String] -> IO ()
 showHelp app args = do
-       (initApp app args) >>= runReaderT (help app)
-       exitWith ExitSuccess
+        (initApp app args) >>= runReaderT (help app)
+        exitWith ExitSuccess
 
 showVersion :: (Default opts, Default config) => Application opts config -> IO ()
 showVersion app = do
@@ -92,11 +92,11 @@ handleCommand app (command:args)
         | command == "man" = showMan
         | otherwise = initApp app args >>= loop1
         where
-               showMan = initApp app args >>= loopMan
-               loopMan st = runReaderT (man app) st
-               loop1 st = runReaderT run st
-               -- docCmds :: (Default config1) => [Command config1]
-               -- docCmds = [helpCmd{cmdHandler = help app}, manCmd{cmdHandler = man app}]
-               run = act $ filter (\x -> cmdName x == command) (appCmds app)
-               act [] = helpErr app
-               act (s:_) = cmdHandler s
+                showMan = initApp app args >>= loopMan
+                loopMan st = runReaderT (man app) st
+                loop1 st = runReaderT run st
+                -- docCmds :: (Default config1) => [Command config1]
+                -- docCmds = [helpCmd{cmdHandler = help app}, manCmd{cmdHandler = man app}]
+                run = act $ filter (\x -> cmdName x == command) (appCmds app)
+                act [] = helpErr app
+                act (s:_) = cmdHandler s

--- a/examples/ui-cmd-hello.hs
+++ b/examples/ui-cmd-hello.hs
@@ -15,7 +15,7 @@ import UI.Command
 world :: Command ()
 
 world = defCmd {
-       	        cmdName = "world",
+                cmdName = "world",
                 cmdHandler = worldHandler,
                 cmdCategory = "Greetings",
                 cmdShortDesc = "An implementation of the standard software greeting."
@@ -28,7 +28,7 @@ worldHandler = liftIO $ putStrLn "Hello world!"
 --
 
 times = defCmd {
-       	        cmdName = "times",
+                cmdName = "times",
                 cmdHandler = timesHandler,
                 cmdCategory = "Cat Math",
                 cmdShortDesc = "A repetition of salutation",
@@ -48,15 +48,15 @@ hello :: Application () ()
 hello = def {
 	        appName = "hello",
                 appVersion = "0.1",
-		appAuthors = ["Joe R. Hacker"],
+                appAuthors = ["Joe R. Hacker"],
                 appBugEmail = "bugs@example.com",
                 appShortDesc = "UI.Command example program",
                 appLongDesc = longDesc,
-	        appCategories = ["Greetings", "Cat Math"],
-		appSeeAlso = ["tractorgen"],
-		appProject = "Haskell",
-	        appCmds = [world, times]
-	}
+                appCategories = ["Greetings", "Cat Math"],
+                appSeeAlso = ["tractorgen"],
+                appProject = "Haskell",
+                appCmds = [world, times]
+        }
 
 longDesc = "a demonstration program for the UI.Command framework."
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,6 @@
+resolver: lts-7.13
+packages:
+- '.'
+extra-deps: []
+flags: {}
+extra-package-dbs: []

--- a/ui-command.cabal
+++ b/ui-command.cabal
@@ -26,14 +26,14 @@ Cabal-Version:       >= 1.2
 
 ------------------------------------------------------------
 library
-    Build-Depends:   base < 5, mtl >= 2.0.0.0 && < 3, time, old-locale, data-default
+    Build-Depends:   base < 5, mtl >= 2.0.0.0 && < 3, time, time-locale-compat, data-default
     Exposed-modules: UI.Command
     Other-modules:   UI.Command.App
-                     UI.Command.Application
-                     UI.Command.Command
-                     UI.Command.Doc
-                     UI.Command.Main
-                     UI.Command.Render
+                   , UI.Command.Application
+                   , UI.Command.Command
+                   , UI.Command.Doc
+                   , UI.Command.Main
+                   , UI.Command.Render
 
 ------------------------------------------------------------
 -- hello example
@@ -42,3 +42,11 @@ library
 Executable ui-cmd-hello
     Main-Is:         ui-cmd-hello.hs
     Hs-Source-Dirs:  ., examples
+    Other-modules:   UI.Command
+                   , UI.Command.App
+                   , UI.Command.Application
+                   , UI.Command.Command
+                   , UI.Command.Doc
+                   , UI.Command.Main
+                   , UI.Command.Render
+


### PR DESCRIPTION
The latest release version does not build with recent GHC releases. These changes fix that and facilitate continuing maintenance of ui-command.

* Move to time-local-compat (old-locale was removed in ~7.8)
* implement Stack
* remove tab character usage